### PR TITLE
introduce quick check for error-logger

### DIFF
--- a/src/flatlog.erl
+++ b/src/flatlog.erl
@@ -23,6 +23,11 @@
 -spec format(LogEvent, Config) -> unicode:chardata() when
       LogEvent :: logger:log_event(),
       Config :: logger:formatter_config().
+format(Map = #{msg := {report, #{label := {error_logger, _}, format := Format, args := Terms}}}, UsrConfig) ->
+    format(Map#{msg := {report,
+                        #{unstructured_log =>
+                              unicode:characters_to_binary(io_lib:format(Format, Terms))}}},
+           UsrConfig);
 format(#{level:=Level, msg:={report, Msg}, meta:=Meta}, UsrConfig) when is_map(Msg) ->
     Config = apply_defaults(UsrConfig),
     NewMeta = maps:merge(Meta, #{level => Level


### PR DESCRIPTION
Might not catch all the case, but right now, when a message is generated with old library by call like `error_logger:info_msg(Format, Args)`, then the formater simply write all the parameter has a map. This result in really hard log to read. I do not know if the approach the right one and if other cases should be checked. This kind of check looks similar to what the old module `error_logger` are  doing

```erlang
%% taken from error_logger.erl:409
report_to_format(#{label:={?MODULE,_},
                   format:=Format,
                   args:=Args}) ->
    %% This is not efficient, but needed for backwards compatibility
    %% in giving faulty arguments to the *_msg functions.
    try io_lib:scan_format(Format,Args) of
        _ -> {Format,Args}
    catch _:_ ->
            {"ERROR: ~tp - ~tp",[Format,Args]}
    end;
```